### PR TITLE
Extract collision from tile class

### DIFF
--- a/server/src/core/game_map.dart
+++ b/server/src/core/game_map.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: public_member_api_docs, sort_constructors_first, lines_longer_than_80_chars
+// ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'package:shared_events/shared_events.dart';
 import 'package:tiledjsonreader/map/layer/group_layer.dart';
 import 'package:tiledjsonreader/map/layer/map_layer.dart';
@@ -109,13 +109,22 @@ abstract class GameMap extends GameComponent {
     }
   }
 
-  void _getCollisionFromTile(int tileId, int tileIndex, TiledMap map, TileLayer layer) {
+  void _getCollisionFromTile(
+    int tileId,
+    int tileIndex,
+    TiledMap map,
+    TileLayer layer,
+  ) {
     final tile = getTileDetails(map.tileSets!, tileId);
 
     if (tile?.typeOrClass == 'collision') {
       final tileWidth = map.tileWidth ?? 0;
       final tileHeight = map.tileHeight ?? 0;
-      final position = getTilePosition(layer: layer, map: map, tileIndex: tileIndex);
+      final position = getTilePosition(
+        layer: layer,
+        map: map,
+        tileIndex: tileIndex,
+      );
       _collisions.add(
         GameRectangle(
           position: position,
@@ -127,7 +136,9 @@ abstract class GameMap extends GameComponent {
 
   TileSetItem? getTileDetails(List<TileSetDetail> tileSets, int tileId) {
     for (final tileSet in tileSets) {
-      final tileTilesetIndex = tileSet.tiles?.indexWhere((tile) => (tile.id! + tileSet.firsTgId!) == tileId) ?? -1;
+      final tileTilesetIndex = tileSet.tiles?.indexWhere(
+        (tile) => (tile.id! + tileSet.firsTgId!) == tileId,
+      ) ?? -1;
       if (tileTilesetIndex > -1) {
         return tileSet.tiles![tileTilesetIndex];
       }
@@ -135,7 +146,11 @@ abstract class GameMap extends GameComponent {
     return null;
   }
 
-  GameVector getTilePosition({required int tileIndex, required TileLayer layer, required TiledMap map}) {
+  GameVector getTilePosition({
+    required int tileIndex,
+    required TileLayer layer,
+    required TiledMap map,
+  }) {
     final xTileCount = tileIndex % layer.width!;
     final yTileCount = tileIndex ~/ layer.width!;
     final xTilePosition = xTileCount * map.tileWidth!;

--- a/server/test/src/core/game_map_test.dart
+++ b/server/test/src/core/game_map_test.dart
@@ -1,0 +1,46 @@
+import 'package:shared_events/shared_events.dart';
+import 'package:test/test.dart';
+import 'package:tiledjsonreader/map/layer/tile_layer.dart';
+import 'package:tiledjsonreader/map/tile_set_detail.dart';
+import 'package:tiledjsonreader/map/tiled_map.dart';
+import 'package:tiledjsonreader/tile_set/tile_set_item.dart';
+
+import '../../../src/core/game_map.dart';
+import '../../../src/game/maps/desert.dart';
+
+void main() {
+  group('GameMap', () {
+    late TileLayer layer;
+    late TiledMap map;
+    late GameMap gameMap;
+
+    setUp(() {
+      layer = TileLayer(width: 3, height: 3, data: [0, 0, 0, 0, 1, 0, 0, 0, 0])
+        ..offsetX = 0
+        ..offsetY = 0;
+      map = TiledMap(
+        tileHeight: 16,
+        tileWidth: 16,
+        width: 3,
+        height: 3,
+        tileSets: [
+          TileSetDetail()
+            ..tiles = [
+              TileSetItem(id: 0),
+              TileSetItem(id: 1)..typeOrClass = 'collision',
+            ],
+        ],
+        layers: [layer],
+      );
+      gameMap = DesertMap(id: 'mock-id', name: 'mock-name', path: 'mock-path');
+    });
+
+    test('getTilePosition index 0', () {
+      expect(gameMap.getTilePosition(tileIndex: 0, layer: layer, map: map), GameVector(x: 0, y: 0));
+    });
+
+    test('getTilePosition index 4', () {
+      expect(gameMap.getTilePosition(tileIndex: 4, layer: layer, map: map), GameVector(x: 16, y: 16));
+    });
+  });
+}


### PR DESCRIPTION
## What does this PR do
Implemented a way to get the collision from the tile class.

## How to use the functionality
When you are in a Tileset and change a tile class to `collision`, this tile will have collision when used in the map.

![image](https://github.com/RafaelBarbosatec/bonfire_multiplayer/assets/16373553/b7c421e1-b2f4-4b24-a803-927eff1bb02a)
